### PR TITLE
Fix Client request return type

### DIFF
--- a/FlightStats/RestClient.php
+++ b/FlightStats/RestClient.php
@@ -25,7 +25,6 @@ class RestClient
      *
      * @param string $apiCall the API call function
      * @param array $params Parameters (Optional)
-     * @return array
      */
     protected function request($apiCall, $params = [])
     {


### PR DESCRIPTION
Guzzle Client returns with `\Psr\Http\Message\ResponseInterface` instead of `array`.
Leaving the inherited return type for proper type hinting.